### PR TITLE
lower meteor player damage

### DIFF
--- a/prototypes/base-edits/entity.lua
+++ b/prototypes/base-edits/entity.lua
@@ -38,4 +38,4 @@ data.raw["accumulator"]["basic-accumulator"].fast_replaceable_group = "accumulat
 data.raw["solar-panel"]["solar-panel"].fast_replaceable_group = "solar-panel"
 data.raw["generator"]["steam-engine"].fast_replaceable_group = "steam-engine"
 data.raw["construction-robot"]["construction-robot"].repair_pack = "repair-pack-0"
-data.raw["player"]["player"].max_health = 1000
+--data.raw["player"]["player"].max_health = 1000

--- a/scripts/functions.lua
+++ b/scripts/functions.lua
@@ -13,6 +13,9 @@ function MeteorSpawn(meteor)
   for _, nearbyentity in ipairs(game.findentities{getboundingbox(position, meteor.area)}) do
     if nearbyentity.health then
       if nearbyentity.name == name then --this IS necessary, even with health=500000, the damage at ground zero is practically infinite
+      elseif nearbyentity.name == "player" then
+        nearbyentity.damage(math.min((50*meteor.area/util.distance(position, nearbyentity.position)), (nearbyentity.health-1)), game.forces.enemy) --same calc, but limited to prevent player death
+      --elseif nearbyentity.name == "player" then nearbyentity.damage(math.min(50, nearbyentity.health-1), game.forces.enemy) --explicit damage of 50 or 1 less than current health to prevent death.
       else nearbyentity.damage((50*meteor.area/util.distance(position, nearbyentity.position)), game.forces.enemy)
       end
   --else nearbyentity.destroy() -- optional


### PR DESCRIPTION
Here's two possible ways, both are limited to prevent player death by using math.min(damage, health-1), but the first can deal less than 50 damage if they have full health (depending on meteor type and player distance from it) whereas the second deals 50 (or health-1) if they are _anywhere_ within the damage zone.
Take your pick as to which you like :)
