### PR TITLE
Fixed crafting button not apearing on load

### DIFF
--- a/DyTech-Tools/control.lua
+++ b/DyTech-Tools/control.lua
@@ -14,8 +14,9 @@ end)
 
 game.onload(function()
   toCraft = toCraft or {}
-  if not game.player.gui.left.add({type="button", name="showModularCraftingGUI", caption="Craft Modular Tool!"}) then game.player.gui.left.add({type="button", name="showModularCraftingGUI", caption="Craft Modular Tool!"}) end
-end)
+   if game.player.gui.left.showModularCraftingGUI == nil then 
+     game.player.gui.left.add({type="button", name="showModularCraftingGUI", caption="Craft Modular Tool!"})
+   end
 
 game.onevent(defines.events.ontick, function(event)
 


### PR DESCRIPTION
changed the code so it detects if the button existence is == to none then add the button instead of the old trying to see if the button has not loaded and load the button after (if the button exists and no load of the button was realized before then it would load/create the button then the game would throw an error saying that it exists already and neither save nor load)
