### PR TITLE
Fixed Solar Panel mk2 power

### DIFF
--- a/MAIN-DyTech-War/prototypes/equipment/entity.lua
+++ b/MAIN-DyTech-War/prototypes/equipment/entity.lua
@@ -291,7 +291,7 @@ data:extend(
       type = "electric",
       usage_priority = "primary-output"
     },
-    power = "30W"
+    power = "3kW"
   },
   {
     type = "solar-panel-equipment",


### PR DESCRIPTION
Vanilla Solar Panel has 1kW, dytech mk2 had 30W and mk has 9kW.
By changing mk3 to 3kW, it now properly triples each step.