### PR TITLE
Fixed error where scale was the tint due to Type not being used

### DIFF
--- a/MAIN-DyTech-Power/prototypes/functions.lua
+++ b/MAIN-DyTech-Power/prototypes/functions.lua
@@ -177,7 +177,7 @@ return
     }
 end
 
-function SteamHorizontalPictures(Type, Scale, Tint)
+function SteamHorizontalPictures(Scale, Tint)
 return
     {
       filename = "__base__/graphics/entity/steam-engine/steam-engine-horizontal.png",
@@ -191,7 +191,7 @@ return
     }
 end
 
-function SteamVerticalPictures(Type, Scale, Tint)
+function SteamVerticalPictures(Scale, Tint)
 return
     {
       filename = "__base__/graphics/entity/steam-engine/steam-engine-vertical.png",


### PR DESCRIPTION
In MAIN-DyTech-Power\prototypes\steam-engines\high\high-entity.lua line 35 and 36 the function 
SteamHorizontalPictures and SteamVerticalPictures in MAIN-DyTech-Power\prototypes\functions.lua were called with incorrect arguments which caused the scale to be a table. When WaiTex tried to use the scale an error would be thrown due to the scale being a table instead of a number. The fix was to remove the Type argument in the two functions as it wasn't used which made the arguments given to the functions correct. 